### PR TITLE
Removing client id hash function

### DIFF
--- a/web-component/mqttFetch.js
+++ b/web-component/mqttFetch.js
@@ -27,10 +27,6 @@ class MqttFetch extends HTMLElement {
         this.attachShadow({mode: 'open'});
 
         // Create a client instance
-        // NOTE: If you have client issues its because there is another client connected with this name
-        // Choose another random client id and it should fix the problem
-        // You can determine this by opening dev tools and if it says socket closed that is the problem
-        // TODO: FIX ABOVE -- kinda fixed but perhaps a better fix can be implemented
         this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), "");
 
         this.client.onConnectionLost = function(responseObject){

--- a/web-component/mqttFetch.js
+++ b/web-component/mqttFetch.js
@@ -26,23 +26,12 @@ class MqttFetch extends HTMLElement {
         // Initialize shadow root
         this.attachShadow({mode: 'open'});
 
-        // TODO: This should be optimized or another method should be implemented.
-        // This is a helper function that generates a random client id.
-        function makeid(length) {
-            let result           = '';
-            const characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-            const charactersLength = characters.length;
-            for ( let i = 0; i < length; i++ ) {
-              result += characters.charAt(Math.floor(Math.random() * charactersLength));
-            }
-            return result;
-        }
         // Create a client instance
         // NOTE: If you have client issues its because there is another client connected with this name
         // Choose another random client id and it should fix the problem
         // You can determine this by opening dev tools and if it says socket closed that is the problem
         // TODO: FIX ABOVE -- kinda fixed but perhaps a better fix can be implemented
-        this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), makeid(8));
+        this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), "");
 
         this.client.onConnectionLost = function(responseObject){
             console.log("Connection Lost" + responseObject.errorMessage);

--- a/web-component/mqttSend.js
+++ b/web-component/mqttSend.js
@@ -24,11 +24,6 @@ class MqttSend extends HTMLElement {
         this.attachShadow({mode: 'open'});
 
         // Create a client instance
-        // NOTE: It appears as tho connecting on the sender side has some issues
-        // refreshing multiple times works for me until in devtools you don't see
-        // Connection LostAMQJS0008I Socket closed. This is likely do to using a public mqtt
-        // server... We can spin up our own some time soon
-        // TODO: FIX ABOVE -- kinda fixed but perhaps a better fix can be implemented
         this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), "");
 
         this.client.onConnectionLost = function(responseObject){

--- a/web-component/mqttSend.js
+++ b/web-component/mqttSend.js
@@ -23,24 +23,13 @@ class MqttSend extends HTMLElement {
         this.userId = "anonymous";
         this.attachShadow({mode: 'open'});
 
-        // TODO: This should be optimized or another method should be implemented.
-        // This is a helper function that generates a random client id.
-        function makeid(length) {
-            let result           = '';
-            const characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-            const charactersLength = characters.length;
-            for ( let i = 0; i < length; i++ ) {
-                result += characters.charAt(Math.floor(Math.random() * charactersLength));
-            }
-            return result;
-        }
         // Create a client instance
         // NOTE: It appears as tho connecting on the sender side has some issues
         // refreshing multiple times works for me until in devtools you don't see
         // Connection LostAMQJS0008I Socket closed. This is likely do to using a public mqtt
         // server... We can spin up our own some time soon
         // TODO: FIX ABOVE -- kinda fixed but perhaps a better fix can be implemented
-        this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), makeid(8));
+        this.client = new Paho.MQTT.Client("broker.mqttdashboard.com", Number(8000), "");
 
         this.client.onConnectionLost = function(responseObject){
             console.log("Connection Lost" + responseObject.errorMessage);


### PR DESCRIPTION
Removed unneeded generate client id function.

Paho MQTT Client API states that they generate a random id when given the empty string.

I tested that mqtt send/fetch still connect